### PR TITLE
Bug fix: 2x dissmiss notification

### DIFF
--- a/src/js/snarl.js
+++ b/src/js/snarl.js
@@ -151,7 +151,9 @@
                 }
 
                 Snarl.notifications[id].removeTimer = setTimeout(function() {
-                    notification.parentElement.removeChild(notification);
+                    if (null !== notification.parentElement) {
+                        notification.parentElement.removeChild(notification);
+                    }
                 }, 500);
 
                 clearTimeout(Snarl.notifications[id].timer);


### PR DESCRIPTION
When a notification timeout occurs and tries to remove the notification, if it is already removed then Snarl still tries to get access to parent.element even when it's null. This adds a null check to resolve this bug.